### PR TITLE
Allow spaces in values of arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 module.exports = (args) => {
   const options = {}
   const params = args.filter(arg => {
-    const doubleDashMatch = arg.match(/^--(\w[\w-.]*)(=(\S+))?$/)
+    const doubleDashMatch = arg.match(/^--(\w[\w-.]*)(=(.+))?$/)
 
     if (doubleDashMatch) {
       options[doubleDashMatch[1]] = Number(doubleDashMatch[3]) || doubleDashMatch[3] || true
       return false
     }
 
-    const singleDashMatch = arg.match(/^-(\w)(=(\S+))?$/)
+    const singleDashMatch = arg.match(/^-(\w)(=(.+))?$/)
 
     if (singleDashMatch) {
       options[singleDashMatch[1]] = Number(singleDashMatch[3]) || singleDashMatch[3] || true

--- a/index.spec.js
+++ b/index.spec.js
@@ -18,6 +18,8 @@ describe('microargs', () => {
     expect(microargs(['--abc=123'])).toEqual({params: [], options: {abc: 123}})
     expect(microargs(['-a=http://www.google.com'])).toEqual({params: [], options: {a: 'http://www.google.com'}})
     expect(microargs(['--abc=http://www.google.com'])).toEqual({params: [], options: {abc: 'http://www.google.com'}})
+    expect(microargs(['-s=hello world'])).toEqual({params: [], options: {s: 'hello world'}})
+    expect(microargs(['--say=hello world'])).toEqual({params: [], options: {say: 'hello world'}})
   })
 
   it('parses params and options combined', () => {


### PR DESCRIPTION
Hey!

I love runjs! However, I can't use spaces in arguments. This modification will allow for spaces.

For this runjs function
```javascript
function hello() {
    console.log(JSON.stringify(options(this)));
    console.log('argv', process.argv)
}
```
The following will currently be output:
```bash
runjs hello --say="hello world"
> {}
> argv [ 'node.exe',  'run.js',  'hello',  '--say=hello world' ]
```

The expected output for runjs is:
```bash
>  {say: "hello world"}
```